### PR TITLE
Feature 116470003 ghost s3 compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,12 +26,23 @@ function logInfo(info) {
     console.log('info in ghost-s3', info);
 };
 
+function getTargetDir() {
+    var now = moment();
+    return now.format('YYYY/MM/');
+};
+
+function getTargetName(image, targetDir) {
+    var ext = path.extname(image.name);
+    var name = path.basename(image.name, ext).replace(/\W/g, '_');
+
+    return targetDir + name + '-' + Date.now() + ext;
+};
+
 S3Store.prototype.save = function(image) {
-    var self = this;
     if (!options) return Bluebird.reject('ghost-s3 is not configured');
 
-    var targetDir = self.getTargetDir();
-    var targetFilename = self.getTargetName(image, targetDir);
+    var targetDir = getTargetDir();
+    var targetFilename = getTargetName(image, targetDir);
 
     var s3 = new AWS.S3({
         accessKeyId: options.accessKeyId,
@@ -93,19 +104,5 @@ S3Store.prototype.serve = function() {
             .pipe(res);
     };
 };
-
-S3Store.prototype.getTargetDir = function() {
-    var now = moment();
-    return now.format('YYYY/MM/');
-};
-
-S3Store.prototype.getTargetName = function(image, targetDir) {
-    var ext = path.extname(image.name);
-    var name = path.basename(image.name, ext).replace(/\W/g, '_');
-
-    return targetDir + name + '-' + Date.now() + ext;
-};
-
-
 
 module.exports = S3Store;

--- a/index.js
+++ b/index.js
@@ -3,79 +3,97 @@
 // # S3 storage module for Ghost blog http://ghost.org/
 var fs = require('fs');
 var path = require('path');
-var nodefn = require('when/node/function');
-var when = require('when');
-var readFile = nodefn.lift(fs.readFile);
-var unlink = nodefn.lift(fs.unlink);
-var AWS = require('aws-sdk');
+var Bluebird = require('bluebird');
+var AWS = require('aws-sdk-promise');
+var moment = require('moment');
+var readFileAsync = Bluebird.promisify(fs.readFile);
 var options = {};
 
 function S3Store(config) {
-  options = config || {};
+    options = config || {};
+}
+
+function getAwsPath(bucket) {
+    var awsPath = 'https://' + bucket + '.s3.amazonaws.com/';
+    return awsPath;
 }
 
 S3Store.prototype.save = function(image) {
     var self = this;
-    if (!options) return when.reject('ghost-s3 is not configured');
+    if (!options) return Bluebird.reject('ghost-s3 is not configured');
 
     var targetDir = self.getTargetDir();
     var targetFilename = self.getTargetName(image, targetDir);
-    var awsPath = options.assetHost ? options.assetHost : 'https://' + options.bucket + '.s3.amazonaws.com/';
 
-    return readFile(image.path)
-    .then(function(buffer) {
-        var s3 = new AWS.S3({
-          accessKeyId: options.accessKeyId,
-          secretAccessKey: options.secretAccessKey,
-          bucket: options.bucket,
-          region: options.region
-        });
-
-        return nodefn.call(s3.putObject.bind(s3), {
-            ACL: 'public-read',
-            Bucket: options.bucket,
-            Key: targetFilename,
-            Body: buffer,
-            ContentType: image.type,
-            CacheControl: 'max-age=' + (30 * 24 * 60 * 60) // 30 days
-        });
-    })
-    .then(function(result) {
-        self.logInfo('ghost-s3', 'Temp uploaded file path: ' + image.path);
-    })
-    .then(function() {
-        return when.resolve(awsPath + targetFilename);
-    })
-    .catch(function(err) {
-        // fs.unlink(image.path, function (err) {
-        //     if (err) throw err;
-        //     errors.logInfo('ghost-s3', 'Successfully deleted temp file uploaded');
-        // });
-        self.logError(err);
-        throw err;
+    var s3 = new AWS.S3({
+        accessKeyId: options.accessKeyId,
+        secretAccessKey: options.secretAccessKey,
+        bucket: options.bucket,
+        region: options.region
     });
+
+    return readFileAsync(image.path)
+        .then(function(buffer) {
+            var params = {
+                ACL: 'public-read',
+                Bucket: options.bucket,
+                Key: targetFilename,
+                Body: buffer,
+                ContentType: image.type,
+                CacheControl: 'max-age=' + (365 * 24 * 60 * 60) // 365 days
+            };
+
+            return s3.putObject(params).promise();
+        })
+        .tap(function() {
+            self.logInfo('ghost-s3', 'Temp uploaded file path: ' + image.path);
+        })
+        .then(function(results) {
+            var awsPath = getAwsPath(options.bucket);
+            return Bluebird.resolve(awsPath + targetFilename);
+        })
+        .catch(function(err) {
+            self.logError(err);
+            throw err;
+        });
 };
 
 // middleware for serving the files
 S3Store.prototype.serve = function() {
-    // a no-op, these are absolute URLs
+    var s3 = new AWS.S3({
+        accessKeyId: options.accessKeyId,
+        secretAccessKey: options.secretAccessKey,
+        bucket: options.bucket,
+        region: options.region
+    });
+
     return function (req, res, next) {
-      next();
+        var params = {
+            Bucket: options.bucket,
+            Key: req.path.replace(/^\//, '')
+        };
+
+        s3.getObject(params)
+            .on('httpHeaders', function(statusCode, headers, response) {
+                res.set(headers);
+            })
+            .createReadStream()
+            .on('error', function(err) {
+                res.status(404);
+                next();
+            })
+            .pipe(res);
     };
 };
 
 S3Store.prototype.getTargetDir = function() {
-    var MONTHS = [
-        'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-        'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
-    ];
-    var now = new Date();
-    return now.getFullYear() + '/' + MONTHS[now.getMonth()] + '/';
+    var now = moment();
+    return now.format('YYYY/MM/');
 };
 
 S3Store.prototype.getTargetName = function(image, targetDir) {
-    var ext = path.extname(image.name),
-        name = path.basename(image.name, ext).replace(/\W/g, '_');
+    var ext = path.extname(image.name);
+    var name = path.basename(image.name, ext).replace(/\W/g, '_');
 
     return targetDir + name + '-' + Date.now() + ext;
 };

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var readFileAsync = Bluebird.promisify(fs.readFile);
 var options = {};
 
 function S3Store(config) {
-    options = config || {};
+    options = config;
 }
 
 function getAwsPath(bucket) {
@@ -38,8 +38,17 @@ function getTargetName(image, targetDir) {
     return targetDir + name + '-' + Date.now() + ext;
 };
 
+function validOptions(opts) {
+    return (opts.accessKeyId && \
+        opts.secretAccessKey && \
+        opts.bucket && \
+        opts.region);
+}
+
 S3Store.prototype.save = function(image) {
-    if (!options) return Bluebird.reject('ghost-s3 is not configured');
+    if (!validOptions(options)) {
+      return Bluebird.reject('ghost-s3 is not configured');
+    }
 
     var targetDir = getTargetDir();
     var targetFilename = getTargetName(image, targetDir);
@@ -59,7 +68,7 @@ S3Store.prototype.save = function(image) {
                 Key: targetFilename,
                 Body: buffer,
                 ContentType: image.type,
-                CacheControl: 'max-age=' + (365 * 24 * 60 * 60) // 365 days
+                CacheControl: 'max-age=' + (1000 * 365 * 24 * 60 * 60) // 365 days
             };
 
             return s3.putObject(params).promise();

--- a/index.js
+++ b/index.js
@@ -39,9 +39,9 @@ function getTargetName(image, targetDir) {
 };
 
 function validOptions(opts) {
-    return (opts.accessKeyId && \
-        opts.secretAccessKey && \
-        opts.bucket && \
+    return (opts.accessKeyId &&
+        opts.secretAccessKey &&
+        opts.bucket &&
         opts.region);
 }
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,14 @@ function getAwsPath(bucket) {
     return awsPath;
 }
 
+function logError(error) {
+    console.log('error in ghost-s3', error);
+};
+
+function logInfo(info) {
+    console.log('info in ghost-s3', info);
+};
+
 S3Store.prototype.save = function(image) {
     var self = this;
     if (!options) return Bluebird.reject('ghost-s3 is not configured');
@@ -46,14 +54,14 @@ S3Store.prototype.save = function(image) {
             return s3.putObject(params).promise();
         })
         .tap(function() {
-            self.logInfo('ghost-s3', 'Temp uploaded file path: ' + image.path);
+            logInfo('ghost-s3', 'Temp uploaded file path: ' + image.path);
         })
         .then(function(results) {
             var awsPath = getAwsPath(options.bucket);
             return Bluebird.resolve(awsPath + targetFilename);
         })
         .catch(function(err) {
-            self.logError(err);
+            logError(err);
             throw err;
         });
 };
@@ -98,12 +106,6 @@ S3Store.prototype.getTargetName = function(image, targetDir) {
     return targetDir + name + '-' + Date.now() + ext;
 };
 
-S3Store.prototype.logError = function(error) {
-    console.log('error in ghost-s3', error);
-};
 
-S3Store.prototype.logInfo = function(info) {
-    console.log('info in ghost-s3', info);
-};
 
 module.exports = S3Store;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "aws-sdk": "^2.1.6",
     "aws-sdk-promise": "^0.0.2",
-    "bluebird": "^2.10.2"
+    "bluebird": "^2.10.2",
+    "moment": "2.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/muzix/ghost-s3",
   "dependencies": {
     "aws-sdk": "^2.1.6",
-    "when": "^3.6.4"
+    "aws-sdk-promise": "^0.0.2",
+    "bluebird": "^2.10.2"
   }
 }


### PR DESCRIPTION
This PR refactors some of the code and also enables migration to S3 if you started your blog without this module and want to start using it. 
## serve

The biggest thing is that instead of `serve()` being a noop, it is now basically a proxy to S3. A request to `/content/images/2016/03/image.png` will yield the same as one to `https://BUCKET.s3.amazonaws.com/2016/03/image.png`, including headers. This means that all you have to do is copy your old `content/images/` up to S3 and you will be able to use this module without breaking your old images or rewriting any posts.
## other changes
- I'll note some in the diff
- Many of the functions don't need to be on the prototype, so I removed them to effectively make them private functions.
