### PR TITLE
log errors from serve

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,7 @@ S3Store.prototype.serve = function() {
             })
             .createReadStream()
             .on('error', function(err) {
+                logError(err);
                 res.status(404);
                 next();
             })


### PR DESCRIPTION
@sandinmyjoints 

Logs errors from when we're trying to serve a file from S3. 
### How to test
#### In ghost-s3-compat
- Pull this branch
- Register local module
  
  ```
  $ npm link
  ```
#### In sd-blog
- Link to local modules
  
  ```
  $ npm link ghost-s3-compat
  ```
- Try to get a file that doesn't exist like
  
  ```
  curl http://localhost:8081/blog/content/images/2016/02/mexico12-9.jpg/
  ```

You should see an error in the server logs
