### PR TITLE
Fix assetHost CDN feature [from Frank Hinek]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # ghost-s3-compat
 
-### 1.0.2
-- Fork from [muzik/ghost-s3](https://github.com/muzix/ghost-s3)
-- Add support for proxying local image requests to S3`
+## 2.0.0
 
+### Changed
+- Restored the ability to specify an `assetHost` in the Ghost `config.js` file.
+- Added logging on image serving errors.
+
+### Fixed
+- Use path-style URLs to construct the S3 endpoint images can be read from to
+avoid certificate validation failures.  This is necessary because common bucket
+naming can include one or more dots `(.)`, such as images.yourdomain.com. If you
+a virtual-hosted–style URL https://images.yourdomain.com.s3.amazonaws.com would
+fail a certificate validity check because AWS uses a *.s3.amazonaws.com wildcard
+cert. The certificate would be deemed invalid because RFC2818 allows matching of
+only a single domain for a given wild card character.
+
+## [1.0.2] - 2016-04-20
+### Changed
+- Add support for proxying local image requests to S3
+
+## [1.0.1] - 2016-04-20
+- Forked [spanishdict/ghost-s3-compat](https://github.com/spanishdict/ghost-s3-compat) from [muzik/ghost-s3](https://github.com/muzix/ghost-s3)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Create new IAM User with permissions to get object from that bucket. Save the
 
 In `config.js`, add a `storage` block for each environment.
 
+```javascript
     storage: {
         active: 'ghost-s3',
         'ghost-s3': {
@@ -34,8 +35,27 @@ In `config.js`, add a `storage` block for each environment.
             region: 'Put_your_bucket_region_here'
         }
     },
+```
+
 
 ### Asset host
+
+You can add `assetHost` to your config to specify a virtual host url. This is
+most frequently used with a content delivery network (CDN) such as CloudFront,
+CloudFlare, or others. The modified `storage` block would be:
+
+```javascript
+    storage: {
+        active: 'ghost-s3',
+        'ghost-s3': {
+            accessKeyId: 'ACCESS_KEY',
+            secretAccessKey: 'SECRET_ACCESS_KEY',
+            bucket: 'S3_BUCKET_NAME',
+            region: 'S3_REGION',
+            assetHost: 'https://cdn.yourdomain.com/'
+        }
+    }
+```
 
 You can add `assetHost` to your config to specify a virtual host url. For more
 information, [read this section](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html)
@@ -46,4 +66,4 @@ in the AWS docs.
 - Original work Copyright (c) 2015 Hoang Pham Huu <phamhuuhoang@gmail.com>
 - Modified work Copyright (c) 2016 Curiosity Media, Inc.
 
-Released under the [MIT license](https://github.com/muzix/ghost-s3/blob/master/LICENSE).
+Released under the [MIT license](https://github.com/spanishdict/ghost-s3-compat/blob/master/LICENSE).

--- a/index.js
+++ b/index.js
@@ -13,8 +13,14 @@ function S3Store(config) {
     options = config;
 }
 
+ /**
+ * Return the URL where image assets can be read.
+ * @param  {String} bucket [AWS S3 bucket name]
+ * @return {String}        [path-style URL of the S3 bucket]
+ */
 function getAwsPath(bucket) {
-    var awsPath = 'https://' + bucket + '.s3.amazonaws.com/';
+    var awsRegion = (options.region == 'us-east-1') ? 's3' : 's3-' + options.region;
+    var awsPath = options.assetHost ? options.assetHost : 'https://' + awsRegion + '.amazonaws.com/' + options.bucket + '/';
     return awsPath;
 }
 


### PR DESCRIPTION
@sandinmyjoints 

Brings over the work by @frankhinek in fixing #4.
### How to test
- set up a local link to this module, like in #7 
- Upload an image  
- You should see a link like `https://s3.amazonaws.com/...`
- Change the src of that image in the markdown to `/blog/content/images/...`
- It should still serve
