### PR TITLE
Update storage adapter for ghost 0.10 compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "aws-sdk": "^2.1.6",
     "aws-sdk-promise": "^0.0.2",
-    "bluebird": "^2.10.2",
-    "moment": "2.12.0"
+    "bluebird": "^2.10.2"
   }
 }


### PR DESCRIPTION
closes #10 

I'm not sure how this works with older versions of ghost, so my recommendation is to release a new major version after this is merged.

This has been tested and ghost 0.10 boots up with these changes 😄 
